### PR TITLE
Fix metadata file permissions

### DIFF
--- a/pkg/pi64/metadata.go
+++ b/pkg/pi64/metadata.go
@@ -24,7 +24,7 @@ func ReadMetadata() (Metadata, error) {
 }
 
 func WriteMetadata(metadata Metadata) error {
-	file, err := os.OpenFile(metadataPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 644)
+	file, err := os.OpenFile(metadataPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Changed created file permissions from 644 (`-w----r--`) to 0644 (`rw-r--r--`).

PoC:
```
dc@jhtc:~/gogo/openfile$ cat main.go
package main

import "os"

func main() {
    os.OpenFile("644", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 644)
    os.OpenFile("0644", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
}
dc@jhtc:~/gogo/openfile$ go run main.go
dc@jhtc:~/gogo/openfile$ ls -la
total 12
drwxrwxr-x 2 dc dc 4096 Jun  9 17:03 .
drwxrwxr-x 3 dc dc 4096 Jun  9 17:02 ..
-rw-r--r-- 1 dc dc    0 Jun  9 17:03 0644
--w----r-- 1 dc dc    0 Jun  9 17:03 644
-rw-rw-r-- 1 dc dc  173 Jun  9 17:03 main.go
```